### PR TITLE
Prevent title wrapping from misaligning the grid of results

### DIFF
--- a/app/styles/app.less
+++ b/app/styles/app.less
@@ -36,4 +36,7 @@ a:hover {
 .video-title {
   text-align: center;
   margin-bottom: 30px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }


### PR DESCRIPTION
When titles wrap onto a second line, it throws off the alignment of items. This is a suggested solution to that problem - having the titles ellipsis at the end of the line. The full title shows when viewing the post.